### PR TITLE
fixed the jpg not supported crash

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ PyQt5>=5.9
 opencv-python>=3.0
 pylint>=1.7.2
 mss>=3.0.1
+Pillow>=4.2.1


### PR DESCRIPTION
When I set the output file to jpeg, I got the following error.

```
C:\project\PUBGIS>python -m pubgis
Traceback (most recent call last):
  File "C:\project\PUBGIS\pubgis\gui.py", line 59, in run
    match.create_output()
  File "C:\project\PUBGIS\pubgis\match.py", line 228, in create_output
    fig.savefig(self.output_file)
  File "C:\Users\handrake\AppData\Local\Programs\Python\Python36-32\lib\site-packages\matplotlib\figure.py", line 1573, in savefig
    self.canvas.print_figure(*args, **kwargs)
  File "C:\Users\handrake\AppData\Local\Programs\Python\Python36-32\lib\site-packages\matplotlib\backend_bases.py", line 2153, in print_figure
    canvas = self._get_output_canvas(format)
  File "C:\Users\handrake\AppData\Local\Programs\Python\Python36-32\lib\site-packages\matplotlib\backend_bases.py", line 2093, in _get_output_canvas
    '%s.' % (format, ', '.join(formats)))
ValueError: Format "jpg" is not supported.
Supported formats: eps, pdf, pgf, png, ps, raw, rgba, svg, svgz.
```

After some googling, I stumbled upon [the possible solution. ](https://stackoverflow.com/questions/8827016/matplotlib-savefig-in-jpeg-format) It seems to be the issue with matplotlib and can be fixed by installing Pillow. So I think a simple fix would be to include Pillow in requirements.txt so every user installs the library before running PUBGIS.
