### PR TITLE
Set default output file when input file is entered

### DIFF
--- a/pubgis/gui.py
+++ b/pubgis/gui.py
@@ -98,6 +98,8 @@ class PUBGISMainWindow(QMainWindow):
                                                filter="Videos (*.mp4)")
         self.video_file_edit.setText(fname)
 
+        self.output_file_edit.setText(os.path.join(os.path.dirname(fname), os.path.splitext(fname)[0] + '.jpg'))
+
     def _select_output_file(self):
         fname, _ = QFileDialog.getSaveFileName(directory=os.path.expanduser('~'),
                                                filter="Images (*.jpg)")


### PR DESCRIPTION
When video file path is entered, set the corresponding output file name with jpeg extension.